### PR TITLE
XML Bill Actions Parsing

### DIFF
--- a/src/main/java/gov/nysenate/openleg/model/bill/BillAction.java
+++ b/src/main/java/gov/nysenate/openleg/model/bill/BillAction.java
@@ -31,27 +31,6 @@ public class BillAction implements Serializable, Comparable<BillAction>
     /** The text of this action. */
     private String text = "";
 
-    /** Bill amendment version, typically single character A, B, C ... . */
-    private String billAmd = "";// there is a Version class
-
-    /** Action code. */
-    private int code = 0;
-
-    /** Data code. Can be code or bill number, depending on action code. */
-    private int data = 0;
-
-    /** Data amd. Unknown purpose. Single character. */
-    private String dataAmd = "";
-
-    /** Post date. Unknown purpose. */
-    private LocalDate postDate;
-
-    /** Act session year. Unknown purpose; does not conform to session year odd-only numbering. */
-    private int actSessionYear;
-
-    /** Indicates whether or not the BillAction was parsed by XML (true) or bill action text (false) */
-    private boolean fromXML;
-
     /** --- Constructors --- */
 
     public BillAction() {
@@ -76,64 +55,6 @@ public class BillAction implements Serializable, Comparable<BillAction>
         this.setSequenceNo(sequenceNo);
     }
 
-    /**
-     * Fully constructs a new action.
-     *
-     * @param date LocalDate - The date of the action
-     * @param text String - The text of the action
-     * @param chamber Chamber - The chamber this bill action occurred in
-     * @param sequenceNo int - Indicates the ordering of this action
-     * @param billId BillId - The id of the bill the action was performed on
-     * @param fromXML boolean - Set whether or not the BillAction was parsed from XML
-     */
-    /*
-    public BillAction(LocalDate date, String text, Chamber chamber, int sequenceNo, BillId billId, boolean fromXML) {
-        super();
-        this.setDate(date);
-        this.setText(text);
-        this.setBillId(billId);
-        this.setChamber(chamber);
-        this.setSequenceNo(sequenceNo);
-        this.setFromXML(fromXML);
-    }*/
-
-    /**
-     * Fully constructs a new action from XML source.
-     *
-     * @param date LocalDate - The date of the action
-     * @param text String - The text of the action
-     * @param chamber Chamber - The chamber this bill action occurred in
-     * @param sequenceNo int - Indicates the ordering of this action
-     * @param billAmd String -
-     * @param code int - Action code from XML Data
-     * @param data int - Data code from XML Data;
-     *             represents different types of data based on the action code (e.g. committee codes, bill numbers)
-     * @param dataAmd String -
-     * @param postDate LocalDate -
-     * @param actSessionYear int - Unknown year value that does not conform to the session year odd-only rule
-     * @param fromXML boolean - Set whether or not the BillAction was parsed from XML
-     * @param billId BillId - The id of the bill the action was performed on
-     */
-    /*
-    public BillAction(LocalDate date, String text, Chamber chamber, int sequenceNo,
-                      String billAmd, int code, int data, String dataAmd, LocalDate postDate, int actSessionYear, boolean fromXML,
-                      BillId billId) {
-        super();
-        this.setDate(date);
-        this.setText(text);
-        this.setBillId(billId);
-        this.setChamber(chamber);
-        this.setSequenceNo(sequenceNo);
-
-        this.setBillAmd(billAmd);
-        this.setCode(code);
-        this.setData(data);
-        this.setDataAmd(dataAmd);
-        this.setPostDate(postDate);
-        this.setActSessionYear(actSessionYear);
-        this.setFromXML(fromXML);
-    }*/
-
     /** --- Overrides --- */
 
     @Override
@@ -155,19 +76,12 @@ public class BillAction implements Serializable, Comparable<BillAction>
                Objects.equals(this.date, other.date) &&
                Objects.equals(this.sequenceNo, other.sequenceNo) &&
                Objects.equals(this.chamber, other.chamber) &&
-               StringUtils.equalsIgnoreCase(this.text, other.text) &&
-               Objects.equals(this.code, other.code) &&
-               Objects.equals(this.data, other.data) &&
-               Objects.equals(this.dataAmd, other.dataAmd) &&
-               Objects.equals(this.postDate, other.postDate) &&
-               Objects.equals(this.actSessionYear, other.actSessionYear) &&
-               Objects.equals(this.fromXML, other.fromXML);
+               StringUtils.equalsIgnoreCase(this.text, other.text);
     }
 
     @Override
     public int hashCode() {
-        return 31 * billId.hashCodeBase() + Objects.hash(date, sequenceNo, chamber, text.toLowerCase())
-                + Objects.hash(code, data, dataAmd, postDate, actSessionYear, fromXML);
+        return 31 * billId.hashCodeBase() + Objects.hash(date, sequenceNo, chamber, text.toLowerCase());
     }
 
     @Override
@@ -233,37 +147,4 @@ public class BillAction implements Serializable, Comparable<BillAction>
     public void setText(String text) {
         this.text = text;
     }
-
-
-
-    /** --- XML Getters/Setters --- */
-    /*
-    public String getBillAmd() { return billAmd; }
-
-    public void setBillAmd(String billAmd) { this.billAmd = billAmd; }
-
-    public int getCode() { return code; }
-
-    public void setCode(int code) { this.code = code; }
-
-    public int getData() { return data; }
-
-    public void setData(int data) { this.data = data; }
-
-    public String getDataAmd() { return dataAmd; }
-
-    public void setDataAmd(String dataAmd) { this.dataAmd = dataAmd; }
-
-    public LocalDate getPostDate() { return postDate; }
-
-    public void setPostDate(LocalDate postDate) { this.postDate = postDate; }
-
-    public int getActSessionYear() { return actSessionYear; }
-
-    public void setActSessionYear(int actSessionYear) { this.actSessionYear = actSessionYear; }
-
-    public boolean getFromXML() { return fromXML; }
-
-    public void setFromXML(boolean fromXML) { this.fromXML = fromXML; }
-     */
 }

--- a/src/main/java/gov/nysenate/openleg/model/bill/BillAction.java
+++ b/src/main/java/gov/nysenate/openleg/model/bill/BillAction.java
@@ -86,11 +86,12 @@ public class BillAction implements Serializable, Comparable<BillAction>
      * @param chamber Chamber - The chamber this bill action occurred in
      * @param sequenceNo int - Indicates the ordering of this action
      * @param billAmd String -
-     * @param code int -
-     * @param data int -
+     * @param code int - Action code from XML Data
+     * @param data int - Data code from XML Data;
+     *             represents different types of data based on the action code (e.g. committee codes, bill numbers)
      * @param dataAmd String -
      * @param postDate LocalDate -
-     * @param actSessionYear int -
+     * @param actSessionYear int - Unknown year value that does not conform to the session year odd-only rule
      * @param billId BillId - The id of the bill the action was performed on
      */
     public BillAction(LocalDate date, String text, Chamber chamber, int sequenceNo,
@@ -239,6 +240,6 @@ public class BillAction implements Serializable, Comparable<BillAction>
 
     public void setActSessionYear(int actSessionYear) { this.actSessionYear = actSessionYear; }
 
-    /** fromXML cannot be modified after construction */
+    /** fromXML cannot be modified after the object is constructed */
     public boolean fromXML() { return fromXML; }
 }

--- a/src/main/java/gov/nysenate/openleg/model/bill/BillAction.java
+++ b/src/main/java/gov/nysenate/openleg/model/bill/BillAction.java
@@ -32,7 +32,7 @@ public class BillAction implements Serializable, Comparable<BillAction>
     private String text = "";
 
     /** Bill amendment version, typically single character A, B, C ... . */
-    private String billAmd = "";
+    private String billAmd = "";// there is a Version class
 
     /** Action code. */
     private int code = 0;
@@ -50,13 +50,12 @@ public class BillAction implements Serializable, Comparable<BillAction>
     private int actSessionYear;
 
     /** Indicates whether or not the BillAction was parsed by XML (true) or bill action text (false) */
-    private final boolean fromXML;
+    private boolean fromXML;
 
     /** --- Constructors --- */
 
     public BillAction() {
         super();
-        fromXML = false;
     }
 
     /**
@@ -75,8 +74,28 @@ public class BillAction implements Serializable, Comparable<BillAction>
         this.setBillId(billId);
         this.setChamber(chamber);
         this.setSequenceNo(sequenceNo);
-        fromXML = false;
     }
+
+    /**
+     * Fully constructs a new action.
+     *
+     * @param date LocalDate - The date of the action
+     * @param text String - The text of the action
+     * @param chamber Chamber - The chamber this bill action occurred in
+     * @param sequenceNo int - Indicates the ordering of this action
+     * @param billId BillId - The id of the bill the action was performed on
+     * @param fromXML boolean - Set whether or not the BillAction was parsed from XML
+     */
+    /*
+    public BillAction(LocalDate date, String text, Chamber chamber, int sequenceNo, BillId billId, boolean fromXML) {
+        super();
+        this.setDate(date);
+        this.setText(text);
+        this.setBillId(billId);
+        this.setChamber(chamber);
+        this.setSequenceNo(sequenceNo);
+        this.setFromXML(fromXML);
+    }*/
 
     /**
      * Fully constructs a new action from XML source.
@@ -92,10 +111,12 @@ public class BillAction implements Serializable, Comparable<BillAction>
      * @param dataAmd String -
      * @param postDate LocalDate -
      * @param actSessionYear int - Unknown year value that does not conform to the session year odd-only rule
+     * @param fromXML boolean - Set whether or not the BillAction was parsed from XML
      * @param billId BillId - The id of the bill the action was performed on
      */
+    /*
     public BillAction(LocalDate date, String text, Chamber chamber, int sequenceNo,
-                      String billAmd, int code, int data, String dataAmd, LocalDate postDate, int actSessionYear,
+                      String billAmd, int code, int data, String dataAmd, LocalDate postDate, int actSessionYear, boolean fromXML,
                       BillId billId) {
         super();
         this.setDate(date);
@@ -110,8 +131,8 @@ public class BillAction implements Serializable, Comparable<BillAction>
         this.setDataAmd(dataAmd);
         this.setPostDate(postDate);
         this.setActSessionYear(actSessionYear);
-        fromXML = true;
-    }
+        this.setFromXML(fromXML);
+    }*/
 
     /** --- Overrides --- */
 
@@ -216,6 +237,7 @@ public class BillAction implements Serializable, Comparable<BillAction>
 
 
     /** --- XML Getters/Setters --- */
+    /*
     public String getBillAmd() { return billAmd; }
 
     public void setBillAmd(String billAmd) { this.billAmd = billAmd; }
@@ -240,6 +262,8 @@ public class BillAction implements Serializable, Comparable<BillAction>
 
     public void setActSessionYear(int actSessionYear) { this.actSessionYear = actSessionYear; }
 
-    /** fromXML cannot be modified after the object is constructed */
-    public boolean fromXML() { return fromXML; }
+    public boolean getFromXML() { return fromXML; }
+
+    public void setFromXML(boolean fromXML) { this.fromXML = fromXML; }
+     */
 }

--- a/src/main/java/gov/nysenate/openleg/model/bill/BillAction.java
+++ b/src/main/java/gov/nysenate/openleg/model/bill/BillAction.java
@@ -81,7 +81,7 @@ public class BillAction implements Serializable, Comparable<BillAction>
 
     @Override
     public int hashCode() {
-        return 31 * billId.hashCodeBase() + Objects.hash(date, sequenceNo, chamber, text);
+        return 31 * billId.hashCodeBase() + Objects.hash(date, sequenceNo, chamber, text.toLowerCase());
     }
 
     @Override

--- a/src/main/java/gov/nysenate/openleg/model/bill/BillAction.java
+++ b/src/main/java/gov/nysenate/openleg/model/bill/BillAction.java
@@ -31,10 +31,32 @@ public class BillAction implements Serializable, Comparable<BillAction>
     /** The text of this action. */
     private String text = "";
 
+    /** Bill amendment version, typically single character A, B, C ... . */
+    private String billAmd = "";
+
+    /** Action code. */
+    private int code = 0;
+
+    /** Data code. Can be code or bill number, depending on action code. */
+    private int data = 0;
+
+    /** Data amd. Unknown purpose. Single character. */
+    private String dataAmd = "";
+
+    /** Post date. Unknown purpose. */
+    private LocalDate postDate;
+
+    /** Act session year. Unknown purpose; does not conform to session year odd-only numbering. */
+    private int actSessionYear;
+
+    /** Indicates whether or not the BillAction was parsed by XML (true) or bill action text (false) */
+    private final boolean fromXML;
+
     /** --- Constructors --- */
 
     public BillAction() {
         super();
+        fromXML = false;
     }
 
     /**
@@ -53,6 +75,41 @@ public class BillAction implements Serializable, Comparable<BillAction>
         this.setBillId(billId);
         this.setChamber(chamber);
         this.setSequenceNo(sequenceNo);
+        fromXML = false;
+    }
+
+    /**
+     * Fully constructs a new action from XML source.
+     *
+     * @param date LocalDate - The date of the action
+     * @param text String - The text of the action
+     * @param chamber Chamber - The chamber this bill action occurred in
+     * @param sequenceNo int - Indicates the ordering of this action
+     * @param billAmd String -
+     * @param code int -
+     * @param data int -
+     * @param dataAmd String -
+     * @param postDate LocalDate -
+     * @param actSessionYear int -
+     * @param billId BillId - The id of the bill the action was performed on
+     */
+    public BillAction(LocalDate date, String text, Chamber chamber, int sequenceNo,
+                      String billAmd, int code, int data, String dataAmd, LocalDate postDate, int actSessionYear,
+                      BillId billId) {
+        super();
+        this.setDate(date);
+        this.setText(text);
+        this.setBillId(billId);
+        this.setChamber(chamber);
+        this.setSequenceNo(sequenceNo);
+
+        this.setBillAmd(billAmd);
+        this.setCode(code);
+        this.setData(data);
+        this.setDataAmd(dataAmd);
+        this.setPostDate(postDate);
+        this.setActSessionYear(actSessionYear);
+        fromXML = true;
     }
 
     /** --- Overrides --- */
@@ -76,12 +133,19 @@ public class BillAction implements Serializable, Comparable<BillAction>
                Objects.equals(this.date, other.date) &&
                Objects.equals(this.sequenceNo, other.sequenceNo) &&
                Objects.equals(this.chamber, other.chamber) &&
-               StringUtils.equalsIgnoreCase(this.text, other.text);
+               StringUtils.equalsIgnoreCase(this.text, other.text) &&
+               Objects.equals(this.code, other.code) &&
+               Objects.equals(this.data, other.data) &&
+               Objects.equals(this.dataAmd, other.dataAmd) &&
+               Objects.equals(this.postDate, other.postDate) &&
+               Objects.equals(this.actSessionYear, other.actSessionYear) &&
+               Objects.equals(this.fromXML, other.fromXML);
     }
 
     @Override
     public int hashCode() {
-        return 31 * billId.hashCodeBase() + Objects.hash(date, sequenceNo, chamber, text.toLowerCase());
+        return 31 * billId.hashCodeBase() + Objects.hash(date, sequenceNo, chamber, text.toLowerCase())
+                + Objects.hash(code, data, dataAmd, postDate, actSessionYear, fromXML);
     }
 
     @Override
@@ -147,4 +211,34 @@ public class BillAction implements Serializable, Comparable<BillAction>
     public void setText(String text) {
         this.text = text;
     }
+
+
+
+    /** --- XML Getters/Setters --- */
+    public String getBillAmd() { return billAmd; }
+
+    public void setBillAmd(String billAmd) { this.billAmd = billAmd; }
+
+    public int getCode() { return code; }
+
+    public void setCode(int code) { this.code = code; }
+
+    public int getData() { return data; }
+
+    public void setData(int data) { this.data = data; }
+
+    public String getDataAmd() { return dataAmd; }
+
+    public void setDataAmd(String dataAmd) { this.dataAmd = dataAmd; }
+
+    public LocalDate getPostDate() { return postDate; }
+
+    public void setPostDate(LocalDate postDate) { this.postDate = postDate; }
+
+    public int getActSessionYear() { return actSessionYear; }
+
+    public void setActSessionYear(int actSessionYear) { this.actSessionYear = actSessionYear; }
+
+    /** fromXML cannot be modified after construction */
+    public boolean fromXML() { return fromXML; }
 }

--- a/src/main/java/gov/nysenate/openleg/processor/bill/BillActionParser.java
+++ b/src/main/java/gov/nysenate/openleg/processor/bill/BillActionParser.java
@@ -14,6 +14,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpressionException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -92,7 +93,12 @@ public class BillActionParser
         int sequenceNo = 1;
 
         // Get NodeList of actions.
-        NodeList actionsList = data.getChildNodes();
+        NodeList actionsList;
+        try {
+            actionsList = xmlHelper.getNodeList("action", data);
+        } catch (XPathExpressionException e) {
+            throw new ParseError("XML parse failure");
+        }
         for (int i = 0; i < actionsList.getLength(); ++i, ++sequenceNo) {
             final Node action_i = actionsList.item(i);
             try {
@@ -114,7 +120,6 @@ public class BillActionParser
             }
             // Fail fast otherwise
             catch (Exception e) {
-                e.printStackTrace();
                 throw new ParseError("XML parse failure");
             }
         }

--- a/src/main/java/gov/nysenate/openleg/processor/bill/BillActionParser.java
+++ b/src/main/java/gov/nysenate/openleg/processor/bill/BillActionParser.java
@@ -9,9 +9,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import javax.xml.parsers.ParserConfigurationException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -25,8 +27,15 @@ import java.util.regex.Pattern;
  */
 public class BillActionParser
 {
-    @Autowired
-    private XmlHelper xmlHelper;
+    private static XmlHelper xmlHelper;
+
+    static {
+        try {
+            xmlHelper = new XmlHelper();
+        } catch (ParserConfigurationException e) {
+            e.printStackTrace();
+        }
+    }
 
     private static final Logger logger = LoggerFactory.getLogger(BillActionParser.class);
 
@@ -34,6 +43,9 @@ public class BillActionParser
 
     /** Date format found in SobiBlock[4] bill event blocks. e.g. 02/04/13 */
     protected static final DateTimeFormatter eventDateFormat = DateTimeFormatter.ofPattern("MM/dd/yy");
+
+    /** Date format found in XML bill event blocks. e.g. 2018-05-08 */
+    protected static final DateTimeFormatter eventDateFormatXML = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     /** The expected format for actions recorded in the bill events [4] block. e.g. 02/04/13 Event Text Here */
     protected static final Pattern billEventPattern = Pattern.compile("([0-9]{2}/[0-9]{2}/[0-9]{2}) (.*)");
@@ -69,6 +81,41 @@ public class BillActionParser
             }
             else {
                 throw new ParseError("Bill Action Pattern not matched: " + line);
+            }
+        }
+        return billActions;
+    }
+
+    public static List<BillAction> parseActionsListXML(BillId billId, Node data) throws ParseError {
+        List<BillAction> billActions = new ArrayList<>();
+        // Impose a strict order to the actions.
+        int sequenceNo = 1;
+
+        // Get NodeList of actions.
+        NodeList actionsList = data.getChildNodes();
+        for (int i = 0; i < actionsList.getLength(); ++i, ++sequenceNo) {
+            final Node action_i = actionsList.item(i);
+            try {
+                // if the sequence gets out of order, stop parsing the XML
+                if (sequenceNo != xmlHelper.getInteger("@no", action_i)) break;
+
+                LocalDate eventDate;
+                eventDate = LocalDate.from(eventDateFormatXML.parse(xmlHelper.getString("actiondate", action_i)));
+                String eventText = xmlHelper.getString("actiondesc", action_i);
+                // Each action is designated to a specific chamber. The actions belonging to the assembly will be
+                // all lowercase and the senate will be all uppercase.
+                Chamber eventChamber = xmlHelper.getString("actionhouse", action_i).equals("S")
+                        ? Chamber.SENATE : Chamber.ASSEMBLY;
+                // Uppercase the action text to aid with regex matching
+                eventText = eventText.toUpperCase().trim();// sometimes the CDATA comes with leading or trailing whitespace chars
+                // Construct and append bill action to list.
+                BillAction action = new BillAction(eventDate, eventText, eventChamber, sequenceNo, billId);
+                billActions.add(action);
+            }
+            // Fail fast otherwise
+            catch (Exception e) {
+                e.printStackTrace();
+                throw new ParseError("XML parse failure");
             }
         }
         return billActions;

--- a/src/main/java/gov/nysenate/openleg/processor/bill/BillSobiProcessor.java
+++ b/src/main/java/gov/nysenate/openleg/processor/bill/BillSobiProcessor.java
@@ -119,7 +119,7 @@ public class BillSobiProcessor extends AbstractBillProcessor implements LegDataP
                     case BILL_INFO: applyBillInfo(data, baseBill, specifiedAmendment, date, unit); break;
                     case LAW_SECTION: applyLawSection(data, baseBill, specifiedAmendment, date); break;
                     case TITLE: applyTitle(data, baseBill, date); break;
-                    case BILL_EVENT:  parseActions(data, baseBill, specifiedAmendment, legDataFragment); break;
+                    case BILL_EVENT:  parseActions(data, baseBill, specifiedAmendment, legDataFragment, null); break;
                     case SAME_AS:  applySameAs(data, specifiedAmendment, legDataFragment, unit); break;
                     case SPONSOR:  applySponsor(data, baseBill, specifiedAmendment, date); break;
                     case CO_SPONSOR:  applyCosponsors(data, baseBill); break;

--- a/src/main/java/gov/nysenate/openleg/processor/bill/billstat/XmlBillStatProcessor.java
+++ b/src/main/java/gov/nysenate/openleg/processor/bill/billstat/XmlBillStatProcessor.java
@@ -156,7 +156,7 @@ public class XmlBillStatProcessor extends AbstractBillProcessor implements LegDa
         billactions = reformatBillActions(billactions);
         Node xmlActions = xmlHelper.getNode("actions", billStatusNode);
 
-        parseActions(billactions, bill, billAmendment, fragment);
+        parseActions(billactions, bill, billAmendment, fragment, xmlActions);
         bill.setYear(BillActionParser.getCalendarYear(xmlActions, xmlHelper));
     }
 

--- a/src/test/java/gov/nysenate/openleg/processor/bill/BillActionParserTest.java
+++ b/src/test/java/gov/nysenate/openleg/processor/bill/BillActionParserTest.java
@@ -62,6 +62,9 @@ public class BillActionParserTest
 
         // counts items
         assertEquals(actions.size(), actionsList1.split("\n").length);
+
+        // first two items are different
+        assertNotEquals(actions.get(0), actions.get(1));
     }
 
     @Test

--- a/src/test/java/gov/nysenate/openleg/processor/bill/BillActionParserTest.java
+++ b/src/test/java/gov/nysenate/openleg/processor/bill/BillActionParserTest.java
@@ -1,16 +1,23 @@
 package gov.nysenate.openleg.processor.bill;
 
+import com.mchange.v2.cfg.PropertiesConfigSource;
 import gov.nysenate.openleg.annotation.UnitTest;
 import gov.nysenate.openleg.model.bill.BillAction;
 import gov.nysenate.openleg.model.bill.BillId;
 import gov.nysenate.openleg.processor.base.ParseError;
 import gov.nysenate.openleg.service.bill.data.BillDataService;
+import gov.nysenate.openleg.util.XmlHelper;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.xml.sax.SAXException;
+import org.w3c.dom.Node;
 
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpressionException;
+import java.io.IOException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -23,40 +30,20 @@ import static org.junit.Assert.fail;
 public class BillActionParserTest
 {
     // @Autowired BillDataService billDataService;
+    private static XmlHelper xmlHelper;
+
+    static {
+        try {
+            xmlHelper = new XmlHelper();
+        } catch (ParserConfigurationException e) {
+            e.printStackTrace();
+        }
+    }
 
     private static final Logger logger = LoggerFactory.getLogger(BillActionParserTest.class);
 
-    private static String actionsList1 =
-        "01/28/09 referred to correction\n" +
-        "03/17/09 reported referred to ways and means\n" +
-        "04/28/09 reported\n" +
-        "04/30/09 advanced to third reading cal.453\n" +
-        "05/04/09 passed assembly\n" +
-        "05/04/09 delivered to senate\n" +
-        "05/04/09 REFERRED TO CODES\n" +
-        "05/26/09 SUBSTITUTED FOR S4366\n" +
-        "05/26/09 3RD READING CAL.391\n" +
-        "06/02/09 recalled from senate\n" +
-        "06/03/09 SUBSTITUTION RECONSIDERED\n" +
-        "06/03/09 RECOMMITTED TO CODES\n" +
-        "06/03/09 RETURNED TO ASSEMBLY\n" +
-        "06/04/09 vote reconsidered - restored to third reading\n" +
-        "06/04/09 amended on third reading 3664a\n" +
-        "06/15/09 repassed assembly\n" +
-        "06/16/09 returned to senate\n" +
-        "06/16/09 COMMITTED TO RULES\n" +
-        "07/17/09 SUBSTITUTED FOR S4366A\n" +
-        "07/17/09 3RD READING CAL.391\n" +
-        "07/16/09 RECOMMITTED TO RULES\n" +
-        "01/06/10 DIED IN SENATE\n" +
-        "01/06/10 RETURNED TO ASSEMBLY\n" +
-        "01/06/10 ordered to third reading cal.276\n" +
-        "01/19/10 committed to correction\n" +
-        "01/26/10 amend and recommit to correction\n" +
-        "01/26/10 print number 3664b";
-
     @Test
-    public void testBillActionParser() {
+    public void billActionParser() {
         List<BillAction> actions = BillActionParser.parseActionsList(new BillId("S3664B", 2013), actionsList1);
         logger.info("{}", actions);
 
@@ -68,7 +55,41 @@ public class BillActionParserTest
     }
 
     @Test
-    public void testSequenceNumber() {
+    public void testBillActionParserXML() throws IOException, SAXException, XPathExpressionException {
+        Node actionsNode = xmlHelper.getNode("actions", xmlHelper.parse(actionsXml1));
+        List<BillAction> actions = BillActionParser.parseActionsListXML(new BillId("S3664B", 2013), actionsNode);
+        logger.info("{}", actions);
+
+        // first two items are different
+        assertNotEquals(actions.get(0), actions.get(1));
+
+        // compare to the old method of parsing
+        List<BillAction> actionsOldMethod = BillActionParser.parseActionsList(new BillId("S3664B", 2013), actionsList2);
+        logger.info("{}", actions);
+
+        // counts items
+        assertEquals(actionsOldMethod.size(), actions.size());
+
+        // compares each list element
+        assertEquals(actionsOldMethod, actions);
+    }
+
+    @Test (expected = ParseError.class)
+    public void billActionParserXMLMissingData() throws IOException, SAXException, XPathExpressionException {
+        Node actionsNode = xmlHelper.getNode("actions", xmlHelper.parse(actionsXml2));
+        List<BillAction> actions = BillActionParser.parseActionsListXML(new BillId("S3664B", 2013), actionsNode);// throws here
+        logger.info("{}", actions);
+    }
+
+    @Test (expected = Exception.class)
+    public void billActionParserXMLCorrupted() throws IOException, SAXException, XPathExpressionException {
+        Node actionsNode = xmlHelper.getNode("actions", xmlHelper.parse(actionsXml3));// throws here
+        List<BillAction> actions = BillActionParser.parseActionsListXML(new BillId("S3664B", 2013), actionsNode);
+        logger.info("{}", actions);
+    }
+
+    @Test
+    public void sequenceNumber() {
         List<BillAction> actions = BillActionParser.parseActionsList(new BillId("S3664B", 2013), actionsList1);
 
         // ensures correct sequencing, sequence numbers
@@ -89,4 +110,296 @@ public class BillActionParserTest
         List<BillAction> actions = BillActionParser.parseActionsList(new BillId("S3664B", 2013), actionsList1);
         assertEquals("2010-01-26 (ASSEMBLY) PRINT NUMBER 3664B", actions.get(actions.size() - 1).toString());
     }
+
+    private static String actionsList1 =
+            "01/28/09 referred to correction\n" +
+                    "03/17/09 reported referred to ways and means\n" +
+                    "04/28/09 reported\n" +
+                    "04/30/09 advanced to third reading cal.453\n" +
+                    "05/04/09 passed assembly\n" +
+                    "05/04/09 delivered to senate\n" +
+                    "05/04/09 REFERRED TO CODES\n" +
+                    "05/26/09 SUBSTITUTED FOR S4366\n" +
+                    "05/26/09 3RD READING CAL.391\n" +
+                    "06/02/09 recalled from senate\n" +
+                    "06/03/09 SUBSTITUTION RECONSIDERED\n" +
+                    "06/03/09 RECOMMITTED TO CODES\n" +
+                    "06/03/09 RETURNED TO ASSEMBLY\n" +
+                    "06/04/09 vote reconsidered - restored to third reading\n" +
+                    "06/04/09 amended on third reading 3664a\n" +
+                    "06/15/09 repassed assembly\n" +
+                    "06/16/09 returned to senate\n" +
+                    "06/16/09 COMMITTED TO RULES\n" +
+                    "07/17/09 SUBSTITUTED FOR S4366A\n" +
+                    "07/17/09 3RD READING CAL.391\n" +
+                    "07/16/09 RECOMMITTED TO RULES\n" +
+                    "01/06/10 DIED IN SENATE\n" +
+                    "01/06/10 RETURNED TO ASSEMBLY\n" +
+                    "01/06/10 ordered to third reading cal.276\n" +
+                    "01/19/10 committed to correction\n" +
+                    "01/26/10 amend and recommit to correction\n" +
+                    "01/26/10 print number 3664b";
+
+    private static String actionsList2 = "05/08/18 REFERRED TO INVESTIGATIONS AND GOVERNMENT OPERATIONS\n" +
+            "06/19/18 COMMITTEE DISCHARGED AND COMMITTED TO RULES\n" +
+            "06/19/18 ORDERED TO THIRD READING CAL.2008\n" +
+            "06/19/18 SUBSTITUTED BY A10768\n" +
+            "01/03/18 referred to governmental operations";
+
+    private static String actionsXml1 = "<actions>" +
+            "<action no=\"1\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>S</actionhouse>" +
+            "<actioncode>1</actioncode>" +
+            "<actiontype>S</actiontype>" +
+            "<actiondata>29</actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-05-08</actiondate>" +
+            "<actiondesc>" +
+            "<![CDATA[REFERRED TO INVESTIGATIONS AND GOVERNMENT OPERATIONS]]>" +
+            "</actiondesc>" +
+            "<actionpostdate>2018-05-08</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "<action no=\"2\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>S</actionhouse>" +
+            "<actioncode>9</actioncode>" +
+            "<actiontype>S</actiontype>" +
+            "<actiondata>27</actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-06-19</actiondate>" +
+            "<actiondesc>" +
+            "<![CDATA[COMMITTEE DISCHARGED AND COMMITTED TO RULES]]>" +
+            "</actiondesc>" +
+            "<actionpostdate>2018-06-19</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "<action no=\"3\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>S</actionhouse>" +
+            "<actioncode>17</actioncode>" +
+            "<actiontype>F</actiontype>" +
+            "<actiondata>2008</actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-06-19</actiondate>" +
+            "<actiondesc>" +
+            "<![CDATA[ORDERED TO THIRD READING CAL.2008]]>" +
+            "</actiondesc>" +
+            "<actionpostdate>2018-06-19</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "<action no=\"4\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>S</actionhouse>" +
+            "<actioncode>23</actioncode>" +
+            "<actiontype>B</actiontype>" +
+            "<actiondata>10768</actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-06-19</actiondate>" +
+            "<actiondesc>" +
+            "<![CDATA[SUBSTITUTED BY A10768 ]]>" +
+            "</actiondesc>" +
+            "<actionpostdate>2018-06-19</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "<action no=\"5\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>A</actionhouse>" +
+            "<actioncode>1</actioncode>" +
+            "<actiontype>S</actiontype>" +
+            "<actiondata>38</actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-01-03</actiondate>" +
+            "<actiondesc><![CDATA[referred to governmental operations]]></actiondesc>" +
+            "<actionpostdate>2018-01-03</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "<action no=\"2018\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>S</actionhouse>" +
+            "<actioncode>350</actioncode>" +
+            "<actiontype>B</actiontype>" +
+            "<actiondata>10768</actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-06-19</actiondate>" +
+            "<actiondesc>" +
+            "<![CDATA[sub-by]]>" +
+            "</actiondesc>" +
+            "<actionpostdate>2018-06-19</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "</actions>";
+
+    // first action is missing all fields
+    private static String actionsXml2 = "<actions>" +
+            "<action no=\"1\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse></actionhouse>" +
+            "<actioncode></actioncode>" +
+            "<actiontype></actiontype>" +
+            "<actiondata></actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate></actiondate>" +
+            "<actiondesc>" +
+            "<![CDATA[]]>" +
+            "</actiondesc>" +
+            "<actionpostdate></actionpostdate>" +
+            "<actionactsessyr></actionactsessyr>" +
+            "</action>" +
+            "<action no=\"2\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>S</actionhouse>" +
+            "<actioncode>9</actioncode>" +
+            "<actiontype>S</actiontype>" +
+            "<actiondata>27</actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-06-19</actiondate>" +
+            "<actiondesc>" +
+            "<![CDATA[COMMITTEE DISCHARGED AND COMMITTED TO RULES]]>" +
+            "</actiondesc>" +
+            "<actionpostdate>2018-06-19</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "<action no=\"3\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>S</actionhouse>" +
+            "<actioncode>17</actioncode>" +
+            "<actiontype>F</actiontype>" +
+            "<actiondata>2008</actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-06-19</actiondate>" +
+            "<actiondesc>" +
+            "<![CDATA[ORDERED TO THIRD READING CAL.2008]]>" +
+            "</actiondesc>" +
+            "<actionpostdate>2018-06-19</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "<action no=\"4\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>S</actionhouse>" +
+            "<actioncode>23</actioncode>" +
+            "<actiontype>B</actiontype>" +
+            "<actiondata>10768</actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-06-19</actiondate>" +
+            "<actiondesc>" +
+            "<![CDATA[SUBSTITUTED BY A10768 ]]>" +
+            "</actiondesc>" +
+            "<actionpostdate>2018-06-19</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "<action no=\"5\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>A</actionhouse>" +
+            "<actioncode>1</actioncode>" +
+            "<actiontype>S</actiontype>" +
+            "<actiondata>38</actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-01-03</actiondate>" +
+            "<actiondesc><![CDATA[referred to governmental operations]]></actiondesc>" +
+            "<actionpostdate>2018-01-03</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "<action no=\"2018\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>S</actionhouse>" +
+            "<actioncode>350</actioncode>" +
+            "<actiontype>B</actiontype>" +
+            "<actiondata>10768</actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-06-19</actiondate>" +
+            "<actiondesc>" +
+            "<![CDATA[sub-by]]>" +
+            "</actiondesc>" +
+            "<actionpostdate>2018-06-19</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "</actions>";
+
+    // random closing tags added/removed
+    private static String actionsXml3 = "<actions>" +
+            "<action no=\"1\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>S</actionhouse>" +
+            "<actioncode>1</actioncode>" +
+            "<actiontype>S</actiontype>" +
+            "<actiondata>29</actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-05-08</actiondate>" +
+            "<actiondesc>" +
+            "<![CDATA[REFERRED TO INVESTIGATIONS AND GOVERNMENT OPERATIONS]]>" +
+            "</actiondesc>" +
+            "<actionpostdate>2018-05-08</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "<action no=\"2\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>S</actionhouse>" +
+            "<actioncode>9<actioncode>" +
+            "<actiontype>S</actiontype>" +
+            "<actiondata>27</actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-06-19</actiondate>" +
+            "<actiondesc>" +
+            "<![CDATA[COMMITTEE DISCHARGED AND COMMITTED TO RULES]]>" +
+            "</actiondesc>" +
+            "<actionpostdate>2018-06-19</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "<action no=\"3\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>S</actionhouse>" +
+            "<actioncode>17</actioncode>" +
+            "<actiontype>F</actiontype>" +
+            "<actiondata>2008<actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-06-19</actiondate>" +
+            "<actiondesc>" +
+            "<![CDATA[ORDERED TO THIRD READING CAL.2008]]>" +
+            "</actiondesc>" +
+            "<actionpostdate>2018-06-19</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "<action no=\"4\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>S</actionhouse>" +
+            "<actioncode>23</actioncode>" +
+            "<actiontype>B</actiontype>" +
+            "<actiondata>10768</actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-06-19</actiondate>" +
+            "<actiondesc>" +
+            "<![CDATA[SUBSTITUTED BY A10768 ]]>" +
+            "</actiondesc>" +
+            "<actionpostdate>2018-06-19</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "<action no=\"5\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>A</actionhouse>" +
+            "<actioncode>1</actioncode>" +
+            "<actiontype>S</actiontype>" +
+            "<actiondata>38</actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-01-03</actiondate>" +
+            "<actiondesc><![CDATA[referred to governmental operations]]></actiondesc>" +
+            "<actionpostdate>2018-01-03</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "<action no=\"2018\">" +
+            "<actionbillamd></actionbillamd>" +
+            "<actionhouse>S</actionhouse>" +
+            "<actioncode>350</actioncode>" +
+            "<actiontype>B</actiontype>" +
+            "<actiondata>10768</actiondata>" +
+            "<actiondataamd></actiondataamd>" +
+            "<actiondate>2018-06-19</actiondate>" +
+            "<actiondesc>" +
+            "<![CDATA[sub-by]]>" +
+            "</actiondesc>" +
+            "<actionpostdate>2018-06-19</actionpostdate>" +
+            "<actionactsessyr>2018</actionactsessyr>" +
+            "</action>" +
+            "<actions>";
 }

--- a/src/test/java/gov/nysenate/openleg/processor/bill/BillActionParserTest.java
+++ b/src/test/java/gov/nysenate/openleg/processor/bill/BillActionParserTest.java
@@ -3,6 +3,7 @@ package gov.nysenate.openleg.processor.bill;
 import gov.nysenate.openleg.annotation.UnitTest;
 import gov.nysenate.openleg.model.bill.BillAction;
 import gov.nysenate.openleg.model.bill.BillId;
+import gov.nysenate.openleg.processor.base.ParseError;
 import gov.nysenate.openleg.service.bill.data.BillDataService;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -73,79 +74,16 @@ public class BillActionParserTest
         }
     }
 
-    @Test
-    public void billActionInequality() {
-        List<BillAction> actions = BillActionParser.parseActionsList(new BillId("S3664B", 2013), actionsList1);
 
-        // 2 different items
-        assertNotEquals(actions.get(0), actions.get(1));
-
-        // null
-        assertNotEquals(actions.get(0), null);
-
-        // bill ID
-        List<BillAction> actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
-        List<BillAction> actionB = BillActionParser.parseActionsList(new BillId("S3665B", 2013), "06/02/09 recalled from senate");
-        assertNotEquals(actionA.get(0), actionB.get(0));
-
-        // date
-        actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
-        actionB = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/10 recalled from senate");
-        assertNotEquals(actionA.get(0), actionB.get(0));
-
-        // session
-        actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
-        actionB = BillActionParser.parseActionsList(new BillId("S3664B", 2011), "06/02/09 recalled from senate");
-        assertNotEquals(actionA.get(0), actionB.get(0));
-
-        // chamber
-        actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 RECALLED FROM SENATE");
-        actionB = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
-        assertNotEquals(actionA.get(0), actionB.get(0));
-    }
-
-    @Test
-    public void billActionEquality() {
-        List<BillAction> actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
-        List<BillAction> actionB = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
-
-        // separately constructed
-        assertEquals(actionA.get(0), actionB.get(0));
-
-        // same object
-        assertEquals(actionA.get(0), actionA.get(0));
-        assertEquals(actionB.get(0), actionB.get(0));
-    }
-
-    @Test
+    @Test (expected = ParseError.class)
     public void invalidDate() {
-        try {
-            List<BillAction> actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/A2/09 recalled from senate");
-            fail();
-        }
-        catch (Exception e) {
-            assertNotEquals(null, e);
-        }
+        List<BillAction> actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/A2/09 recalled from senate");
     }
 
+
     @Test
-    public void actionListSort() {
+    public void printAction() {
         List<BillAction> actions = BillActionParser.parseActionsList(new BillId("S3664B", 2013), actionsList1);
-
-        //sort descending
-        actions.sort(new BillAction.ByEventSequenceDesc());
-
-        // ensures correct sequencing, sequence numbers
-        for (int i = 0; i < actions.size(); ++i) {
-            assertEquals(actions.size() - i, actions.get(i).getSequenceNo());
-        }
-
-        //sort ascending
-        actions.sort(new BillAction.ByEventSequenceAsc());
-
-        // ensures correct sequencing, sequence numbers
-        for (int i = 0; i < actions.size(); ++i) {
-            assertEquals(i + 1, actions.get(i).getSequenceNo());
-        }
+        assertEquals("2010-01-26 (ASSEMBLY) PRINT NUMBER 3664B", actions.get(actions.size() - 1).toString());
     }
 }

--- a/src/test/java/gov/nysenate/openleg/processor/bill/BillActionTest.java
+++ b/src/test/java/gov/nysenate/openleg/processor/bill/BillActionTest.java
@@ -1,0 +1,118 @@
+package gov.nysenate.openleg.processor.bill;
+
+import gov.nysenate.openleg.annotation.UnitTest;
+import gov.nysenate.openleg.model.bill.BillAction;
+import gov.nysenate.openleg.model.bill.BillId;
+import gov.nysenate.openleg.processor.base.ParseError;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@Category(UnitTest.class)
+public class BillActionTest
+{
+    // @Autowired BillDataService billDataService;
+
+    private static final Logger logger = LoggerFactory.getLogger(BillActionTest.class);
+
+    private static String actionsList1 =
+        "01/28/09 referred to correction\n" +
+        "03/17/09 reported referred to ways and means\n" +
+        "04/28/09 reported\n" +
+        "04/30/09 advanced to third reading cal.453\n" +
+        "05/04/09 passed assembly\n" +
+        "05/04/09 delivered to senate\n" +
+        "05/04/09 REFERRED TO CODES\n" +
+        "05/26/09 SUBSTITUTED FOR S4366\n" +
+        "05/26/09 3RD READING CAL.391\n" +
+        "06/02/09 recalled from senate\n" +
+        "06/03/09 SUBSTITUTION RECONSIDERED\n" +
+        "06/03/09 RECOMMITTED TO CODES\n" +
+        "06/03/09 RETURNED TO ASSEMBLY\n" +
+        "06/04/09 vote reconsidered - restored to third reading\n" +
+        "06/04/09 amended on third reading 3664a\n" +
+        "06/15/09 repassed assembly\n" +
+        "06/16/09 returned to senate\n" +
+        "06/16/09 COMMITTED TO RULES\n" +
+        "07/17/09 SUBSTITUTED FOR S4366A\n" +
+        "07/17/09 3RD READING CAL.391\n" +
+        "07/16/09 RECOMMITTED TO RULES\n" +
+        "01/06/10 DIED IN SENATE\n" +
+        "01/06/10 RETURNED TO ASSEMBLY\n" +
+        "01/06/10 ordered to third reading cal.276\n" +
+        "01/19/10 committed to correction\n" +
+        "01/26/10 amend and recommit to correction\n" +
+        "01/26/10 print number 3664b";
+
+    @Test
+    public void billActionInequality() {
+        List<BillAction> actions = BillActionParser.parseActionsList(new BillId("S3664B", 2013), actionsList1);
+
+        // 2 different items
+        assertNotEquals(actions.get(0), actions.get(1));
+
+        // null
+        assertNotEquals(actions.get(0), null);
+
+        // bill ID
+        List<BillAction> actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
+        List<BillAction> actionB = BillActionParser.parseActionsList(new BillId("S3665B", 2013), "06/02/09 recalled from senate");
+        assertNotEquals(actionA.get(0), actionB.get(0));
+
+        // date
+        actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
+        actionB = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/10 recalled from senate");
+        assertNotEquals(actionA.get(0), actionB.get(0));
+
+        // session
+        actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
+        actionB = BillActionParser.parseActionsList(new BillId("S3664B", 2011), "06/02/09 recalled from senate");
+        assertNotEquals(actionA.get(0), actionB.get(0));
+
+        // chamber
+        actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 RECALLED FROM SENATE");
+        actionB = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
+        assertNotEquals(actionA.get(0), actionB.get(0));
+    }
+
+    @Test
+    public void billActionEquality() {
+        List<BillAction> actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
+        List<BillAction> actionB = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
+
+        // separately constructed
+        assertEquals(actionA.get(0), actionB.get(0));
+
+        // same object
+        assertEquals(actionA.get(0), actionA.get(0));
+        assertEquals(actionB.get(0), actionB.get(0));
+    }
+
+    @Test
+    public void actionListSort() {
+        List<BillAction> actions = BillActionParser.parseActionsList(new BillId("S3664B", 2013), actionsList1);
+
+        //sort descending
+        actions.sort(new BillAction.ByEventSequenceDesc());
+
+        // ensures correct sequencing, sequence numbers
+        for (int i = 0; i < actions.size(); ++i) {
+            assertEquals(actions.size() - i, actions.get(i).getSequenceNo());
+        }
+
+        //sort ascending
+        actions.sort(new BillAction.ByEventSequenceAsc());
+
+        // ensures correct sequencing, sequence numbers
+        for (int i = 0; i < actions.size(); ++i) {
+            assertEquals(i + 1, actions.get(i).getSequenceNo());
+        }
+    }
+
+}

--- a/src/test/java/gov/nysenate/openleg/processor/bill/BillActionTest.java
+++ b/src/test/java/gov/nysenate/openleg/processor/bill/BillActionTest.java
@@ -162,6 +162,7 @@ public class BillActionTest
         assertEquals("2019-01-02 (ASSEMBLY) abcdefg", a.toString());
     }
 
+    /*
     @Test
     public void xmlGetSet() {
         BillAction a = new BillAction();
@@ -246,7 +247,7 @@ public class BillActionTest
         assertNotEquals(b, c);
         assertNotEquals(b.hashCode(), c.hashCode());
         assertEquals(c, c);
-    }
+    }*/
 
     @Test
     public void compareTo() {

--- a/src/test/java/gov/nysenate/openleg/processor/bill/BillActionTest.java
+++ b/src/test/java/gov/nysenate/openleg/processor/bill/BillActionTest.java
@@ -58,48 +58,76 @@ public class BillActionTest
         "01/26/10 amend and recommit to correction\n" +
         "01/26/10 print number 3664b";
 
+    private final BillAction actionA = new BillAction(LocalDate.from(eventDateFormat.parse("06/02/09")),
+                                              "recalled from senate",
+                                              Chamber.ASSEMBLY,
+                                              1,
+                                              new BillId("S3664B", 2013));
+    private final BillAction actionB = new BillAction(LocalDate.from(eventDateFormat.parse("06/02/09")),
+                                              "recalled from senate",
+                                              Chamber.ASSEMBLY,
+                                              1,
+                                              new BillId("S3665B", 2013));// different
+    private final BillAction actionC = new BillAction(LocalDate.from(eventDateFormat.parse("06/02/10")),// different
+                                              "recalled from senate",
+                                              Chamber.ASSEMBLY,
+                                              1,
+                                              new BillId("S3664B", 2013));
+    private final BillAction actionD = new BillAction(LocalDate.from(eventDateFormat.parse("06/02/09")),
+                                              "recalled from senate",
+                                              Chamber.ASSEMBLY,
+                                              1,
+                                              new BillId("S3664B", 2011));// different
+    private final BillAction actionE = new BillAction(LocalDate.from(eventDateFormat.parse("06/02/09")),
+                                              "RECALLED FROM SENATE",// different
+                                              Chamber.SENATE,// different
+                                              1,
+                                              new BillId("S3664B", 2013));
+    private final BillAction actionF = new BillAction(LocalDate.from(eventDateFormat.parse("06/02/09")),
+                                              "recalled from senate",
+                                              Chamber.ASSEMBLY,
+                                              2,// different
+                                              new BillId("S3664B", 2013));
     @Test
     public void billActionInequality() {
-        List<BillAction> actions = BillActionParser.parseActionsList(new BillId("S3664B", 2013), actionsList1);
-
-        // 2 different items
-        assertNotEquals(actions.get(0), actions.get(1));
-
         // null
-        assertNotEquals(actions.get(0), null);
+        assertNotEquals(actionA, null);
 
         // bill ID
-        List<BillAction> actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
-        List<BillAction> actionB = BillActionParser.parseActionsList(new BillId("S3665B", 2013), "06/02/09 recalled from senate");
-        assertNotEquals(actionA.get(0), actionB.get(0));
+        assertNotEquals(actionA, actionB);
 
         // date
-        actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
-        actionB = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/10 recalled from senate");
-        assertNotEquals(actionA.get(0), actionB.get(0));
+        assertNotEquals(actionA, actionC);
 
         // session
-        actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
-        actionB = BillActionParser.parseActionsList(new BillId("S3664B", 2011), "06/02/09 recalled from senate");
-        assertNotEquals(actionA.get(0), actionB.get(0));
+        assertNotEquals(actionA, actionD);
 
         // chamber
-        actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 RECALLED FROM SENATE");
-        actionB = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
-        assertNotEquals(actionA.get(0), actionB.get(0));
+        assertNotEquals(actionA, actionE);
+
+        // sequence number
+        assertNotEquals(actionA, actionF);
     }
 
     @Test
     public void billActionEquality() {
-        List<BillAction> actionA = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
-        List<BillAction> actionB = BillActionParser.parseActionsList(new BillId("S3664B", 2013), "06/02/09 recalled from senate");
+        final BillAction action1 = new BillAction(LocalDate.from(eventDateFormat.parse("06/02/09")),
+                "recalled from senate",
+                Chamber.ASSEMBLY,
+                1,
+                new BillId("S3664B", 2013));
+        final BillAction action2 = new BillAction(LocalDate.from(eventDateFormat.parse("06/02/09")),
+                "recalled from senate",
+                Chamber.ASSEMBLY,
+                1,
+                new BillId("S3664B", 2013));
 
         // separately constructed
-        assertEquals(actionA.get(0), actionB.get(0));
+        assertEquals(action1, action2);
 
         // same object
-        assertEquals(actionA.get(0), actionA.get(0));
-        assertEquals(actionB.get(0), actionB.get(0));
+        assertEquals(action1, action1);
+        assertEquals(action2, action2);
     }
 
     @Test
@@ -124,6 +152,17 @@ public class BillActionTest
     }
 
     @Test
+    public void getSet() {
+        BillAction a = new BillAction();
+        a.setDate(LocalDate.from(eventDateFormat.parse("01/02/19")));
+        a.setText("abcdefg");
+        a.setBillId(new BillId("S3664B", 2013));
+        a.setChamber(Chamber.ASSEMBLY);
+        a.setSequenceNo(1);
+        assertEquals("2019-01-02 (ASSEMBLY) abcdefg", a.toString());
+    }
+
+    @Test
     public void xmlGetSet() {
         BillAction a = new BillAction();
         a.setDate(LocalDate.from(eventDateFormat.parse("01/02/19")));
@@ -145,7 +184,8 @@ public class BillActionTest
         assertEquals(LocalDate.from(eventDateFormat.parse("01/30/19")), a.getPostDate());
         a.setActSessionYear(2018);
         assertEquals(2018, a.getActSessionYear());
-        assertFalse(a.fromXML());
+        a.setFromXML(true);
+        assertTrue(a.getFromXML());
     }
 
     @Test
@@ -160,6 +200,7 @@ public class BillActionTest
                 "V",
                 LocalDate.from(eventDateFormat.parse("01/30/19")),
                 2018,
+                true,
                 new BillId("S3664B", 2013));
         BillAction b = new BillAction(LocalDate.from(eventDateFormat.parse("01/02/19")),
                 "ABCDEFG",//capitalization is different
@@ -171,6 +212,7 @@ public class BillActionTest
                 "V",
                 LocalDate.from(eventDateFormat.parse("01/30/19")),
                 2018,
+                true,
                 new BillId("S3664B", 2013));
         BillAction c = new BillAction(LocalDate.from(eventDateFormat.parse("01/02/19")),
                 "ABCDEFG",//capitalization is different
@@ -182,6 +224,7 @@ public class BillActionTest
                 "V",
                 LocalDate.from(eventDateFormat.parse("01/30/19")),
                 2018,
+                true,
                 new BillId("S3664B", 2013));
 
         assertEquals("2019-01-02 (ASSEMBLY) abcdefg", a.toString());
@@ -192,7 +235,7 @@ public class BillActionTest
         assertEquals("V", a.getDataAmd());
         assertEquals(LocalDate.from(eventDateFormat.parse("01/30/19")), a.getPostDate());
         assertEquals(2018, a.getActSessionYear());
-        assertTrue(a.fromXML());
+        assertTrue(a.getFromXML());
 
         // equality tests
         assertEquals(a, b);


### PR DESCRIPTION
- Finished BillActionParserTest
- Added BillActionTest
- New BillActionParser supports XML actions passed in by DOM Node
- Defaults to new XML parsing strategy with fallback to old strategy on error
- BillAction class .equals() contract fixed (case insensitive text comparisons previously not handled by `hashCode()`)