### PR TITLE
docs: fix stale Java version reference in setup guide (17 → 21)

### DIFF
--- a/docs/backend/index.md
+++ b/docs/backend/index.md
@@ -60,7 +60,7 @@ Clone the Open Legislation codebase to your computer.
     * Automatically download
         * Sources
         * Documentation
-5. Be sure to use Java 17 on this project
+5. Be sure to use Java 21 on this project
 
 ## Database Setup
 


### PR DESCRIPTION
## What

Fixes a stale reference in `docs/backend/index.md` that instructs developers to use **Java 17** when configuring IntelliJ.

The project targets **Java 21** — the `pom.xml` sets `<release>21</release>` and the README lists Java 21 in the tech stack. The setup guide itself already references Java 21 in the install section (line 7) but the IntelliJ configuration step (line 63) still said Java 17.

## Why

New developers following the setup guide will configure IntelliJ with the wrong JDK, causing compilation failures or runtime issues. This is a one-line fix to keep the docs consistent with the actual build target.

## Changes

```diff
-5. Be sure to use Java 17 on this project
+5. Be sure to use Java 21 on this project
```