### PR TITLE
ci: add GitHub Actions workflow for build and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+
+jobs:
+  build-and-test:
+    name: Build and Unit Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: src/main/webapp/package-lock.json
+
+      - name: Compile
+        run: mvn compile -B
+
+      - name: Run unit tests
+        run: mvn test -B


### PR DESCRIPTION
## What

Adds a GitHub Actions CI workflow (`.github/workflows/ci.yml`) that runs on every push and PR to the `dev` branch.

## Why

The repository currently has **no CI/CD pipeline at all** — no GitHub Actions, no Travis, no Jenkins. This means:

- Builds and tests are only run if a developer remembers to do so locally
- Broken code can reach `dev` without detection
- There's no automated signal for PR reviewers

This PR adds the foundational CI step: **build + unit tests on every push/PR**.

## What It Does

| Step | Action | Why |
|---|---|---|
| Checkout | `actions/checkout@v4` | Get the code |
| Set up JDK 21 | `actions/setup-java@v4` (Temurin 21, Maven cache) | Matches `pom.xml` `<release>21</release>` |
| Set up Node.js 20 | `actions/setup-node@v4` (npm cache) | Frontend assets built via `npm ci` during Maven `generate-sources` |
| Compile | `mvn compile -B` | Verifies Java + webpack build succeeds |
| Unit tests | `mvn test -B` | Runs Surefire (`@UnitTest` group — currently 356 tests, 0 failures) |

## What It Doesn't Do (Yet)

This is intentionally a **minimal first step**. Future improvements:

- **Integration tests** (`mvn verify`) — requires PostgreSQL + Elasticsearch service containers; should be a separate job
- **Flyway migration validation** — requires a PostgreSQL service container
- **Dependency scanning** — can be added via Dependabot or OWASP Dependency-Check
- **Security scanning** — CodeQL or Semgrep

These can be added incrementally once this basic workflow is merged.

## Verification

I ran `mvn compile` and `mvn test` locally before submitting this PR:
- `mvn compile` — **BUILD SUCCESS** (Java + webpack frontend)
- `mvn test` — **BUILD SUCCESS**, 356 tests, 0 failures, 0 errors, 5 skipped