### PR TITLE
ci: add Dependabot config for maven, npm, and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+
+updates:
+  # Java dependencies (pom.xml)
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      # Group Spring Framework updates together
+      spring:
+        patterns:
+          - "org.springframework*"
+      # Group Apache Commons libraries
+      apache-commons:
+        patterns:
+          - "org.apache.commons*"
+          - "commons-*"
+      # Group Elasticsearch client updates
+      elasticsearch:
+        patterns:
+          - "co.elastic.clients*"
+      # Group Jackson updates
+      jackson:
+        patterns:
+          - "com.fasterxml.jackson*"
+
+  # JavaScript dependencies (src/main/webapp/package.json)
+  - package-ecosystem: npm
+    directory: "/src/main/webapp"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      # Group React ecosystem updates
+      react:
+        patterns:
+          - "react"
+          - "react-*"
+          - "@types/react*"
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## What

Adds a `.github/dependabot.yml` configuration file to manage automated dependency updates.

## Why

Dependabot is already active on this repo (12 open PRs), but there's no explicit config file. This means:

- **No update schedule** — PRs are created at random times, creating review noise
- **No grouping** — each dependency bump is a separate PR (e.g., Shiro core and Shiro web are separate PRs #145 and #147)
- **No npm ecosystem coverage** — the frontend `package.json` in `src/main/webapp/` is not being monitored
- **No GitHub Actions monitoring** — the new CI workflow (`actions/checkout`, `actions/setup-java`, etc.) won't get version updates

## What This Configures

| Ecosystem | Directory | Schedule | Grouping | PR Limit |
|---|---|---|---|---|
| **Maven** (`pom.xml`) | `/` | Weekly (Mon) | Spring, Apache Commons, Elasticsearch, Jackson grouped | 10 |
| **npm** (`package.json`) | `/src/main/webapp` | Weekly (Mon) | React ecosystem grouped | 10 |
| **GitHub Actions** | `/` | Monthly | — | 5 |

### Grouping Rationale

- **Spring Framework** — core, web, webmvc, websocket, messaging, context-support, jdbc should update together to avoid version mismatches
- **Apache Commons** — cli, csv, io, lang3, text, validator grouped for review convenience
- **Elasticsearch** — client updates should be atomic
- **Jackson** — core, databind, dataformat-xml, datatype-guava, datatype-jsr310 grouped
- **React** — react + react-* packages grouped to avoid peer dependency conflicts

## Compatibility

- This config **coexists** with existing Dependabot PRs — it only affects future update behavior
- Grouping will **reduce the number of PRs** by combining related dependency bumps
- The weekly Monday schedule creates a predictable review cadence
- The PR limit of 10 prevents overwhelming maintainers

## Notes

This PR is complementary to #150 (CI workflow). Together they provide:
1. Automated testing on every PR (#150)
2. Automated dependency updates with security alerts (this PR)